### PR TITLE
patches call to indexclient

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
-
+      with:
+        ref: ${{ github.ref }}
     - name: Login to Quay.io
       uses: docker/login-action@v2
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
 
         # Login to Quay.io and build image
         docker login quay.io
-        docker build -t $REPO:$BRANCH .
+        docker build -t $REPO:$BRANCH --build-arg BRANCH=$BRANCH .
 
         # Add 'latest' tag to 'main' image
         if [[ $BRANCH == 'main' ]]; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,13 +22,14 @@ jobs:
     - name: Build and push image
       run: |
         # Set Image tag to the branch name
+        RAW_BRANCH_NAME=$(echo ${GITHUB_REF#refs/*/})
         BRANCH=$(echo ${GITHUB_REF#refs/*/} | tr / _)
         REPO=quay.io/ohsu-comp-bio/gen3-image-viewer
         echo "Setting image tag to $REPO:$BRANCH"
 
         # Login to Quay.io and build image
         docker login quay.io
-        docker build -t $REPO:$BRANCH --build-arg BRANCH=$BRANCH .
+        docker build -t $REPO:$BRANCH --build-arg BRANCH=$RAW_BRANCH_NAME .
 
         # Add 'latest' tag to 'main' image
         if [[ $BRANCH == 'main' ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12
-
+ARG BRANCH=development
 WORKDIR /app
 
 ADD "https://api.github.com/repos/ACED-IDP/image_viewer/commits?per_page=1" latest_commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ WORKDIR /app
 
 ADD "https://api.github.com/repos/ACED-IDP/image_viewer/commits?per_page=1" latest_commit
 
-RUN git clone  https://github.com/ACED-IDP/image_viewer
+# Clone the specific branch
+RUN git clone --branch $BRANCH https://github.com/ACED-IDP/image_viewer.git
+
 WORKDIR /app/image_viewer
-RUN git checkout $BRANCH 
-RUN git pull origin $BRANCH 
+
 RUN pip install --no-cache-dir .
 RUN git log --oneline
 CMD ["uvicorn", "image_viewer.app:app", "--reload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD "https://api.github.com/repos/ACED-IDP/image_viewer/commits?per_page=1" late
 
 RUN git clone  https://github.com/ACED-IDP/image_viewer
 WORKDIR /app/image_viewer
-RUN git checkout development
+RUN git checkout $BRANCH 
 RUN pip install --no-cache-dir .
 RUN git log --oneline
 CMD ["uvicorn", "image_viewer.app:app", "--reload"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ADD "https://api.github.com/repos/ACED-IDP/image_viewer/commits?per_page=1" late
 RUN git clone  https://github.com/ACED-IDP/image_viewer
 WORKDIR /app/image_viewer
 RUN git checkout $BRANCH 
+RUN git pull origin $BRANCH 
 RUN pip install --no-cache-dir .
 RUN git log --oneline
 CMD ["uvicorn", "image_viewer.app:app", "--reload"]

--- a/image_viewer/__init__.py
+++ b/image_viewer/__init__.py
@@ -1,0 +1,18 @@
+import indexclient.client
+
+
+def monkey_patch_indexclient__get():
+    """Monkey patch IndexClient._get to ensure 'auth' is set and log calls."""
+    original__get = indexclient.client.IndexClient._get
+
+    def patched__get(self, *args, **kwargs):
+        """Patch to ensure 'auth' is set and log the call."""
+        if 'auth' not in kwargs:
+            kwargs['auth'] = self.auth
+        return original__get(self, *args, **kwargs)
+
+    indexclient.client.IndexClient._get = patched__get
+
+
+# main
+monkey_patch_indexclient__get()

--- a/image_viewer/app.py
+++ b/image_viewer/app.py
@@ -48,22 +48,17 @@ async def view_object(object_id: str, authorization: str = Header(None), access_
 
     token = None
 
-    logger.error("in view object")
-
     if authorization and authorization.startswith("Bearer "):
         token = authorization.split(" ")[1]  # Extract token from "Bearer <token>"
     elif access_token:
         token = access_token
 
-    logger.error(f"in view object token {token}")
     # If no token is found, raise a 404 Not Found error
     if not token:
         raise HTTPException(status_code=404, detail="Token not found")
 
     try:
-        logger.error(f"in view object {object_id} {settings.base_url}")
         redirect_url = aviator_url(object_id, token, settings.base_url)
-        logger.error(f"in view object {redirect_url}")
 
         return RedirectResponse(url=redirect_url)
     except HTTPException as e:


### PR DESCRIPTION
## TL/DR

This PR:
* patches call to indexclient


---

## 🛠 PR #8: Monkey Patch `IndexClient._get` to Ensure Auth Header

### 🔍 Summary

This PR introduces a monkey patch to the `IndexClient._get` method in the `indexclient` Python library to ensure that every `_get()` request includes the required `auth` parameter. This patch helps prevent unauthenticated requests when the caller forgets to pass `auth` explicitly.

---

### 📚 Use Case

In the `image_viewer` application (or its backend), the `IndexClient._get()` method from the `indexclient` library is used to retrieve metadata from Gen3's Indexd service. However, the base method requires the caller to manually supply the `auth` parameter.

Forgetting to pass `auth` results in failed requests or hard-to-debug authentication issues. This monkey patch injects `self.auth` automatically if it's missing, ensuring consistent authenticated requests.

---

### ✅ Acceptance Criteria

* [x] Replace `IndexClient._get` with a wrapped version (`patched__get`) at runtime.
* [x] If the caller omits the `auth` keyword argument, set `auth=self.auth` automatically.
* [x] Maintain all existing behavior of `_get` when `auth` is provided.
* [x] Logically scoped and side-effect free outside the intended monkey patch.
* [x] Patch is applied during module load (`monkey_patch_indexclient__get()` is called at the end of the file).

---

### 🧪 Acceptance Tests

Manual verification steps:

1. **Without patch:**

   * Call `IndexClient._get(...)` without `auth=`
   * Expect failure or 403 Unauthorized.

2. **With patch:**

   * Call same method without `auth=`
   * Request succeeds using `self.auth`.

3. **Explicit auth override:**

   * Call `_get(..., auth=some_other_auth)`
   * Confirm that `some_other_auth` is used, not `self.auth`.

